### PR TITLE
fix sleeping time after philo death

### DIFF
--- a/philo/philo.c
+++ b/philo/philo.c
@@ -54,7 +54,8 @@ int	start_philo(t_arg *args, t_philo *ph)
 		return (1);
 	while (i < args->num_of_philos)
 	{
-		if (pthread_join(ph[i].thread, NULL) != 0)
+		//if (pthread_join(ph[i].thread, NULL) != 0)
+		if (pthread_detach(ph[i].thread) != 0)
 			return (1);
 		i++;
 	}


### PR DESCRIPTION
This fix resolves an issue where the program would hang for the full sleep time if the philosopher's sleep time exceeded their time to die. Instead of exiting immediately after detecting a philosopher's death, the program would wait for the remaining sleep time to elapse.
Example of the issue:  `./philo 4 310 2147483647 210`
**Expected behavior**:
The program should exit immediately after detecting the philosopher's death.

Actual behavior (before the fix):
The program hangs for the full sleep duration (2147483647) before exiting.

Resolution:
Replaced `pthread_join` with `pthread_detach`. This allows the program to exit immediately after the monitor thread detects a philosopher's death. The thread responsible for sleeping is detached, avoiding the unnecessary hang.

